### PR TITLE
Fix things that break automated Javadoc JAR creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     classpath 'com.android.tools.build:gradle:1.3.0'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-    classpath 'me.tatarka:gradle-retrolambda:3.2.3'
   }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,18 +1,12 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
-apply plugin: 'me.tatarka.retrolambda'
 
 version = "0.20.0"
 
 android {
   compileSdkVersion 23
   buildToolsVersion "23.0.1"
-
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
-  }
 
   defaultConfig {
     minSdkVersion 14

--- a/library/src/main/java/id/ridsatrio/kopi/meta/Arguments.java
+++ b/library/src/main/java/id/ridsatrio/kopi/meta/Arguments.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 
 /**
  * Static helper class to handle Argument validations.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 10/22/15.
  */
 public final class Arguments {

--- a/library/src/main/java/id/ridsatrio/kopi/net/Connections.java
+++ b/library/src/main/java/id/ridsatrio/kopi/net/Connections.java
@@ -6,7 +6,7 @@ import android.net.NetworkInfo;
 
 /**
  * Static helper class to deal with network connectivity.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 8/19/15.
  */
 public final class Connections {

--- a/library/src/main/java/id/ridsatrio/kopi/os/CurrentBuildVersion.java
+++ b/library/src/main/java/id/ridsatrio/kopi/os/CurrentBuildVersion.java
@@ -4,7 +4,7 @@ import android.os.Build;
 
 /**
  * Static helper class for dealing with user's OS version.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 10/22/15.
  */
 public final class CurrentBuildVersion {

--- a/library/src/main/java/id/ridsatrio/kopi/persistence/db/CursorWrapper.java
+++ b/library/src/main/java/id/ridsatrio/kopi/persistence/db/CursorWrapper.java
@@ -4,7 +4,7 @@ import android.database.Cursor;
 
 /**
  * A wrapper that simplifies Cursor for data extraction.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 22/08/2015.
  */
 public class CursorWrapper {

--- a/library/src/main/java/id/ridsatrio/kopi/persistence/keyvalue/KeyValueStore.java
+++ b/library/src/main/java/id/ridsatrio/kopi/persistence/keyvalue/KeyValueStore.java
@@ -3,7 +3,7 @@ package id.ridsatrio.kopi.persistence.keyvalue;
 /**
  * Represents a persistence store where each value is mapped through a
  * String key.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 9/25/15.
  */
 public interface KeyValueStore {

--- a/library/src/main/java/id/ridsatrio/kopi/persistence/keyvalue/NoSuchKeyException.java
+++ b/library/src/main/java/id/ridsatrio/kopi/persistence/keyvalue/NoSuchKeyException.java
@@ -3,7 +3,7 @@ package id.ridsatrio.kopi.persistence.keyvalue;
 /**
  * An exception indicating that there's no value exists on a store with
  * a given key.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 10/23/15.
  */
 public class NoSuchKeyException extends Exception {

--- a/library/src/main/java/id/ridsatrio/kopi/persistence/keyvalue/SharedPreferenceStore.java
+++ b/library/src/main/java/id/ridsatrio/kopi/persistence/keyvalue/SharedPreferenceStore.java
@@ -11,7 +11,7 @@ import id.ridsatrio.kopi.meta.Arguments;
 /**
  * Represents a {@link KeyValueStore} that backs itself using
  * Android's {@link SharedPreferences}.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 9/25/15.
  */
 public class SharedPreferenceStore implements KeyValueStore {

--- a/library/src/main/java/id/ridsatrio/kopi/resource/Colors.java
+++ b/library/src/main/java/id/ridsatrio/kopi/resource/Colors.java
@@ -5,7 +5,7 @@ import android.support.annotation.ColorRes;
 
 /**
  * Static helper class to manipulate Colors.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 30/08/2015.
  */
 public final class Colors {

--- a/library/src/main/java/id/ridsatrio/kopi/resource/Dimens.java
+++ b/library/src/main/java/id/ridsatrio/kopi/resource/Dimens.java
@@ -5,7 +5,7 @@ import android.support.annotation.DimenRes;
 
 /**
  * Static helper class to manipulate Dimens.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 10/23/15.
  */
 public final class Dimens {

--- a/library/src/main/java/id/ridsatrio/kopi/resource/Drawables.java
+++ b/library/src/main/java/id/ridsatrio/kopi/resource/Drawables.java
@@ -9,7 +9,7 @@ import id.ridsatrio.kopi.os.CurrentBuildVersion;
 
 /**
  * Static helper class to manipulate Drawables.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 10/23/15.
  */
 public final class Drawables {

--- a/library/src/main/java/id/ridsatrio/kopi/resource/Strings.java
+++ b/library/src/main/java/id/ridsatrio/kopi/resource/Strings.java
@@ -5,7 +5,7 @@ import android.support.annotation.StringRes;
 
 /**
  * Static helper class to manipulate Strings.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 8/19/15.
  */
 public final class Strings {

--- a/library/src/main/java/id/ridsatrio/kopi/security/Permissions.java
+++ b/library/src/main/java/id/ridsatrio/kopi/security/Permissions.java
@@ -12,7 +12,7 @@ import id.ridsatrio.kopi.os.CurrentBuildVersion;
 
 /**
  * Static helper class to deal with Android 6.0's new Permission system.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 10/22/15.
  */
 public final class Permissions {

--- a/library/src/main/java/id/ridsatrio/kopi/security/Permissions.java
+++ b/library/src/main/java/id/ridsatrio/kopi/security/Permissions.java
@@ -163,7 +163,7 @@ public final class Permissions {
    * @param activity   The activity to be checked.
    * @param permission The name of the permission being checked.
    * @return {@code true} if the permission has been granted (or if
-   * users is on API < 23) or {@code false} otherwise.
+   * users is on API 22 or below) or {@code false} otherwise.
    */
   @SuppressLint("NewApi")
   // Old requests already filtered with CurrentBuildVersion

--- a/library/src/main/java/id/ridsatrio/kopi/ui/activity/AbstractActivity.java
+++ b/library/src/main/java/id/ridsatrio/kopi/ui/activity/AbstractActivity.java
@@ -15,7 +15,7 @@ import butterknife.ButterKnife;
  * to do is to supply your layout's and menu's resource ID, and annotate
  * your view widgets with the standard ButterKnife annotations. (Yep,
  * this class uses ButterKnife to further minimise boilerplate codes.)
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 8/18/15.
  */
 public abstract class AbstractActivity extends AppCompatActivity {

--- a/library/src/main/java/id/ridsatrio/kopi/ui/activity/AbstractNavigationDrawerActivity.java
+++ b/library/src/main/java/id/ridsatrio/kopi/ui/activity/AbstractNavigationDrawerActivity.java
@@ -24,7 +24,7 @@ import id.ridsatrio.kopi.R;
  * to do is to supply your layout's and menu's resource ID, and annotate
  * your view widgets with the standard ButterKnife annotations. (Yep,
  * this class uses ButterKnife to further minimise boilerplate codes.)
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 8/19/15.
  */
 public abstract class AbstractNavigationDrawerActivity extends AppCompatActivity {

--- a/library/src/main/java/id/ridsatrio/kopi/ui/activity/AbstractNavigationDrawerActivity.java
+++ b/library/src/main/java/id/ridsatrio/kopi/ui/activity/AbstractNavigationDrawerActivity.java
@@ -114,11 +114,13 @@ public abstract class AbstractNavigationDrawerActivity extends AppCompatActivity
 
     navigationView.inflateMenu(getNavigationMenuResId());
 
-    navigationView.setNavigationItemSelectedListener((MenuItem menuItem) -> {
-      onNavigationItemSelected(menuItem);
-      menuItem.setChecked(true);
-      drawerLayout.closeDrawers();
-      return true;
+    navigationView.setNavigationItemSelectedListener(new NavigationView.OnNavigationItemSelectedListener() {
+      @Override public boolean onNavigationItemSelected(MenuItem menuItem) {
+        onNavigationItemSelected(menuItem);
+        menuItem.setChecked(true);
+        drawerLayout.closeDrawers();
+        return true;
+      }
     });
   }
 

--- a/library/src/main/java/id/ridsatrio/kopi/ui/activity/PermissionActivity.java
+++ b/library/src/main/java/id/ridsatrio/kopi/ui/activity/PermissionActivity.java
@@ -16,7 +16,7 @@ import id.ridsatrio.kopi.security.Permissions;
  * <b>Use with caution!</b> As the run-time permission system is
  * currently in its earliest of stages and are subjected to change in
  * future releases, so does this class.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 10/23/15.
  */
 public abstract class PermissionActivity extends AbstractActivity {

--- a/library/src/main/java/id/ridsatrio/kopi/ui/adapter/AbstractAdapter.java
+++ b/library/src/main/java/id/ridsatrio/kopi/ui/adapter/AbstractAdapter.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * An abstract to classes that would render a list of data by binding it
  * into a specified view.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 8/19/15.
  */
 public abstract class AbstractAdapter<T> extends BaseAdapter {

--- a/library/src/main/java/id/ridsatrio/kopi/ui/adapter/AbstractRecyclerAdapter.java
+++ b/library/src/main/java/id/ridsatrio/kopi/ui/adapter/AbstractRecyclerAdapter.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * An abstract to classes that would render a list of data by binding it
  * into a specified view.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 8/19/15.
  */
 public abstract class AbstractRecyclerAdapter<T>

--- a/library/src/main/java/id/ridsatrio/kopi/ui/adapter/SimpleViewHolderAdapter.java
+++ b/library/src/main/java/id/ridsatrio/kopi/ui/adapter/SimpleViewHolderAdapter.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * An abstract to classes that would render a list of data by binding it
  * into a specified view.
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 8/19/15.
  */
 public abstract class SimpleViewHolderAdapter<VH extends SimpleViewHolderAdapter.ViewHolder, D>

--- a/library/src/main/java/id/ridsatrio/kopi/ui/fragment/AbstractDialogFragment.java
+++ b/library/src/main/java/id/ridsatrio/kopi/ui/fragment/AbstractDialogFragment.java
@@ -19,7 +19,7 @@ import butterknife.ButterKnife;
  * to do is to supply your layout's and menu's resource ID, and annotate
  * your view widgets with the standard ButterKnife annotations. (Yep,
  * this class uses ButterKnife to further minimise boilerplate codes.)
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 8/19/15.
  */
 public abstract class AbstractDialogFragment extends DialogFragment {

--- a/library/src/main/java/id/ridsatrio/kopi/ui/fragment/AbstractFragment.java
+++ b/library/src/main/java/id/ridsatrio/kopi/ui/fragment/AbstractFragment.java
@@ -20,7 +20,7 @@ import butterknife.ButterKnife;
  * to do is to supply your layout's and menu's resource ID, and annotate
  * your view widgets with the standard ButterKnife annotations. (Yep,
  * this class uses ButterKnife to further minimise boilerplate codes.)
- * <p/>
+ * <p>
  * Created by Ridho Hadi Satrio on 8/19/15.
  */
 public abstract class AbstractFragment extends Fragment {


### PR DESCRIPTION
As it turned out, there's several things that prevented automated Javadoc JAR creation from successfully running.
- Self-enclosing elements
- Retrolambda
- Illegal characters in the comments

These commit were made to mend those things. The Javadoc JAR could now be generated successfully thus enabling us to publish this library in JCenter Maven repository.
